### PR TITLE
Add error message if gadget.ready() fails.

### DIFF
--- a/source/js/app.js
+++ b/source/js/app.js
@@ -26,6 +26,13 @@ $(document).ready(function () {
             console.log("Promise", data);
         });
 
+    }).fail(function(err){
+        // gadget.ready failed, display a message:
+        if (err.responseText.code = "SESSION_NOT_FOUND"){
+            $("#main").html('<p><strong>Error (SESSION_NOT_FOUND)</strong><br/> This can happen when your authorization token has expired. Please try refreshing the entire page.</p>');
+        }
+
+        console.log("gadget.ready fail!", err);
     });
 });
 


### PR DESCRIPTION
This error is frequent with development since the page doesn't get reloaded but the gadget does.